### PR TITLE
feat: docker image serving the plugin via ovos-tts-server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+test
+**/__pycache__
+*.py[cod]
+.pytest_cache
+*.egg-info
+.venv
+TODO.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,46 @@
+name: docker
+
+on:
+  push:
+    branches: [master, dev]
+    tags: ["*.*.*", "V*", "v*"]
+  pull_request:
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - pyproject.toml
+      - .github/workflows/docker.yml
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
+            type=ref,event=tag
+            type=sha,format=short
+      - uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# MaryTTS voices served through ovos-tts-server's ElevenLabs-compatible API.
+#
+# IMPORTANT: this plugin is a THIN CLIENT. It does not synthesize speech itself; it
+# forwards text to an external MaryTTS Java server (or any MaryTTS-compatible server
+# such as OpenTTS / Larynx) over HTTP and returns the WAV it gets back. This image on
+# its own is useless without a reachable MaryTTS server. Use the provided
+# docker-compose.yml, which starts a MaryTTS server sidecar and points this container
+# at it, or set MARYTTS_URL to your own server.
+FROM python:3.11-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . /app
+
+# the plugin + the OVOS TTS server. setuptools<81 keeps ovos-plugin-manager's
+# pkg_resources usage working. ovos-tts-server>=1.13.5a1 carries the non-WAV transcode
+# fix; the alpha floor lets pip resolve the prerelease without --pre.
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir "setuptools<81" "." "ovos-tts-server>=1.13.5a1"
+
+# URL of the external MaryTTS server and the default voice. Override MARYTTS_URL to
+# point at your own server; the compose sidecar is reachable at http://marytts:59125.
+ARG MARYTTS_URL=http://marytts:59125
+ARG MARYTTS_VOICE=cmu-slt-hsmm
+RUN useradd -m -u 1000 ovos \
+    && mkdir -p /home/ovos/.config/mycroft \
+    && printf '{\n  "tts": {\n    "module": "ovos-tts-plugin-marytts",\n    "ovos-tts-plugin-marytts": {\n      "url": "%s",\n      "voice": "%s"\n    }\n  }\n}\n' "${MARYTTS_URL}" "${MARYTTS_VOICE}" \
+        > /home/ovos/.config/mycroft/mycroft.conf \
+    && chown -R 1000:1000 /home/ovos/.config
+USER 1000
+
+EXPOSE 9666
+ENTRYPOINT ["ovos-tts-server", "--engine", "ovos-tts-plugin-marytts", \
+            "--host", "0.0.0.0", "--port", "9666", "--cache"]

--- a/README.md
+++ b/README.md
@@ -31,33 +31,52 @@ engine.get_tts("hello world", "test.wav")
 
 ## Docker
 
-[Docker](https://github.com/synesthesiam/docker-marytts) text to speech server and a collection of hidden semi-Markov model (HSMM) voices for various languages in a multi-platform Docker image.
+This repo ships a container that serves the plugin behind
+[`ovos-tts-server`](https://github.com/OpenVoiceOS/ovos-tts-server) (an
+ElevenLabs-compatible HTTP API) on port `9666`, published to
+`ghcr.io/openvoiceos/ovos-tts-plugin-marytts`.
 
-Supported Platforms:
+> **Requires an external MaryTTS backend.** This plugin is a thin *client*: it
+> forwards text to a separate MaryTTS Java server and returns the WAV it gets back.
+> The plugin container **cannot synthesize on its own** and will fail to serve
+> requests unless a reachable MaryTTS server URL is configured (`url` config key,
+> baked via the `MARYTTS_URL` build arg, default `http://marytts:59125`).
 
-* `amd64` - laptops, desktops, servers
-* `arm/v7` - Raspberry Pi 2/3
-* `arm64` - Raspberry Pi 3+/4
+### Compose (recommended)
+
+`docker-compose.yml` wires both pieces together: a MaryTTS server sidecar
+(`synesthesiam/marytts:5.2`, 19 HSMM voices for 8 languages, port `59125`) plus this
+plugin container pointing at it.
+
+```bash
+$ docker compose up
+```
+
+The ElevenLabs-compatible API is then available at `http://localhost:9666`, backed by
+the MaryTTS server at `http://localhost:59125`.
+
+To use a different voice or point at your own MaryTTS server, rebuild the plugin image
+with the `MARYTTS_URL` / `MARYTTS_VOICE` build args:
+
+```bash
+$ docker build --build-arg MARYTTS_URL=http://my-marytts:59125 \
+               --build-arg MARYTTS_VOICE=dfki-spike-hsmm -t marytts-tts .
+```
+
+### The MaryTTS backend
+
+The [`synesthesiam/marytts`](https://github.com/synesthesiam/docker-marytts) image
+bundles HSMM voices for various languages and runs on `amd64`, `arm/v7` and `arm64`.
 
 ```bash
 $ docker run -it -p 59125:59125 synesthesiam/marytts:5.2
 ```
 
-You should now be able to access the server at [http://localhost:59125](http://localhost:59125)
-
-Beware that this may consume a lot of RAM on a Raspberry Pi!
-
-You can control which voices are loaded with `-v` or `--voice` arguments:
+Beware that this may consume a lot of RAM on a Raspberry Pi. Control which voices are
+loaded with `--voice` to conserve RAM, and list voices with `--voices`:
 
 ```bash
 $ docker run -it -p 59125:59125 synesthesiam/marytts:5.2 --voice cmu-slt-hsmm --voice cmu-rms-hsmm
-```
-
-This will only loaded the necessary JARs for the specified voices, which may help conserve RAM on a Raspberry Pi.
-
-A list of voices can be obtained with:
-
-```bash
 $ docker run -it synesthesiam/marytts:5.2 --voices
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  # External MaryTTS synthesis backend. This plugin CANNOT synthesize on its own; it
+  # is a client to this server. synesthesiam/marytts:5.2 bundles 19 HSMM voices for 8
+  # languages and serves the MaryTTS HTTP API on port 59125.
+  marytts:
+    image: synesthesiam/marytts:5.2
+    container_name: marytts
+    restart: unless-stopped
+    ports:
+      - "59125:59125"
+
+  # The OVOS TTS server exposing the ElevenLabs-compatible API on 9666, backed by the
+  # MaryTTS server above (reached at http://marytts:59125 on the compose network).
+  marytts-tts:
+    image: ghcr.io/openvoiceos/ovos-tts-plugin-marytts:latest
+    # …or build locally: build: .
+    container_name: marytts-tts
+    restart: unless-stopped
+    depends_on:
+      - marytts
+    ports:
+      - "9666:9666"
+    # url + voice are baked as build args (default http://marytts:59125, cmu-slt-hsmm).
+    # To target a different MaryTTS server or voice, rebuild with:
+    #   build: { context: ., args: { MARYTTS_URL: http://host:59125, MARYTTS_VOICE: dfki-spike-hsmm } }
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:9666/status')"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 30s


### PR DESCRIPTION
Adds a container that serves this plugin behind `ovos-tts-server` (ElevenLabs-compatible API) on port 9666, published to `ghcr.io/openvoiceos/ovos-tts-plugin-marytts` from CI.

Files:
- `Dockerfile` — `python:3.11-slim`, installs the plugin + `ovos-tts-server>=1.13.5a1`; bakes a `mycroft.conf` with the MaryTTS `url` + `voice` config keys.
- `docker-compose.yml` — wires two services: a `synesthesiam/marytts:5.2` server sidecar (port 59125) plus this plugin container pointing at it via `MARYTTS_URL=http://marytts:59125`.
- `.dockerignore`, `.github/workflows/docker.yml` (build-only on PRs, push on dev/master/tags), and a rewritten README "Docker" section.

**Runtime caveat — external backend required.** This plugin is a thin *client*: it forwards text to a separate MaryTTS Java server and returns the WAV it gets back. It CANNOT synthesize on its own. The plugin container is useless without a reachable MaryTTS server URL (`url` config key / `MARYTTS_URL` build arg). The compose file provides that backend via the `synesthesiam/marytts:5.2` sidecar (verified on Docker Hub, serves the MaryTTS API on 59125). The image BUILD itself is self-contained and green in CI; only runtime needs the backend.

MaryTTS returns WAV audio directly, so no ffmpeg transcode is needed; the `ovos-tts-server>=1.13.5a1` floor is kept regardless.